### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled command line

### DIFF
--- a/vulnerable-flask-app.py
+++ b/vulnerable-flask-app.py
@@ -1,4 +1,5 @@
 from flask import Flask,jsonify,render_template_string,request,Response,render_template
+import re
 import subprocess
 from werkzeug.datastructures import Headers
 from werkzeug.utils import secure_filename
@@ -114,9 +115,11 @@ def get_admin_mail(control):
 @app.route("/run_file")
 def run_file():
     try:
-        filename=request.args.get("filename")
-        command="/bin/bash "+filename
-        data=subprocess.check_output(command,shell=True)
+        filename = request.args.get("filename")
+        if not re.match(r'^[\w\-]+$', filename):
+            return jsonify(data="Invalid filename"), 400
+        command = ["/bin/bash", filename]
+        data = subprocess.check_output(command)
         return data
     except:
         return jsonify(data="File failed to run"), 200


### PR DESCRIPTION
Potential fix for [https://github.com/Coolreshu16/Vulnerable-app/security/code-scanning/10](https://github.com/Coolreshu16/Vulnerable-app/security/code-scanning/10)

To fix the problem, we should avoid using user input directly in shell commands. Instead, we can use a predefined allowlist of acceptable filenames or validate the user input to ensure it does not contain any malicious content. Additionally, we should avoid using `shell=True` and pass the command and its arguments as a list to `subprocess.check_output`.

The best way to fix the problem without changing existing functionality is to validate the `filename` parameter to ensure it only contains safe characters (e.g., alphanumeric characters, underscores, and hyphens). We can use the `re` module to perform this validation. If the `filename` is not valid, we should return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
