### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled command line

### DIFF
--- a/vulnerable-flask-app.py
+++ b/vulnerable-flask-app.py
@@ -55,8 +55,10 @@ def hello_ssti():
 def get_users():
     try:
         hostname = request.args.get('hostname')
-        command = "dig " + hostname
-        data = subprocess.check_output(command, shell=True)
+        if not re.match(r'^[a-zA-Z0-9.-]+$', hostname):
+            return jsonify(data="Invalid hostname"), 400
+        command = ["dig", hostname]
+        data = subprocess.check_output(command)
         return data
     except:
         data = str(hostname) + " username didn't found"


### PR DESCRIPTION
Potential fix for [https://github.com/Coolreshu16/Vulnerable-app/security/code-scanning/9](https://github.com/Coolreshu16/Vulnerable-app/security/code-scanning/9)

To fix the problem, we should avoid directly using user input in the command string. Instead, we can use a predefined allowlist of acceptable hostnames or validate the input to ensure it only contains safe characters. Additionally, we should avoid using `shell=True` in the `subprocess.check_output` call, as it allows for shell injection vulnerabilities. Instead, we can pass the command and its arguments as a list to `subprocess.check_output`.

The best way to fix the problem without changing existing functionality is to validate the `hostname` parameter to ensure it only contains valid characters (e.g., alphanumeric characters, dots, and hyphens) and then pass it as an argument to `subprocess.check_output` without using `shell=True`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
